### PR TITLE
Atualizada página de crud de Status de Trabalho

### DIFF
--- a/cadastrarUsuario.php
+++ b/cadastrarUsuario.php
@@ -65,9 +65,9 @@
                         <select id="sltStatusInscricao" name="pStatusInscricao">
                             <option disabled selected>Selecione</option>
                             <?php
-                            $listaStatusInscricao = StatusInscricao::getTodosStatusInscricao();
-                            if (is_array($listaStatusInscricao)) {
-                                foreach ($listaStatusInscricao as $statusInscricao) {
+                            $listaStatusTrabalho = StatusInscricao::getTodosStatusInscricao();
+                            if (is_array($listaStatusTrabalho)) {
+                                foreach ($listaStatusTrabalho as $statusInscricao) {
                                     echo "<option value='" . $statusInscricao->getId() . "'>" . $statusInscricao->getStatusInscricao() . "</option>";
                                 }
                             }

--- a/crudStatusInscricao.php
+++ b/crudStatusInscricao.php
@@ -26,9 +26,8 @@
         <div id="carregaPagina">
             <section id="conteudo">
                 <!-- O CONTEÚDO DAS PÁGINAS DEVE APARECER AQUI -->
-                <div id="mensagem"></div>
                 <h2>Gerenciar Status Inscrição</h2>
-                <button src="img/iconEditar.png"
+                <button 
                      onclick='abrePopupForm("Criar Status Inscrição",
                                  "Criar", "phpFuncoes/cadastrarStatusInscricao.php",
                                  <?php
@@ -53,9 +52,9 @@
                         </thead>
                         <tbody>
                             <?php
-                            $listaStatusInscricao = StatusInscricao::getTodosStatusInscricao();
-                            if($listaStatusInscricao != null){
-                                foreach($listaStatusInscricao as $status){
+                            $listaStatusTrabalho = StatusInscricao::getTodosStatusInscricao();
+                            if($listaStatusTrabalho != null){
+                                foreach($listaStatusTrabalho as $status){
                             ?>
                                     <tr>
                                         <td><?php echo $status->getId() ?></td>
@@ -91,7 +90,7 @@
                                 }
                             }
                             else{
-                                echo "Nenhum registro encontrado!";
+                                echo "<tr><td colspan='4'>Nenhum registro encontrado!</td></tr>";
                             }
                             ?>
                         </tbody>

--- a/crudStatusTrabalho.php
+++ b/crudStatusTrabalho.php
@@ -13,6 +13,10 @@
         require_once dirname(__FILE__) . '/includes/sessaoDeUsuario.php';
 
         loginObrigatorio(); //LOGIN OBRIGATÓRIO
+        
+        if (!$usuario->ehAdministrador()) {//SE
+            header("location: inicio.php"); //NÃO FOR O ADMINISTRADOR, REDIRECIONAR PARA A TELA INICIAL
+        }
         ?>
     </head>
     <body>
@@ -21,60 +25,79 @@
         
         <div id="carregaPagina">
             <section id="conteudo">
-                <!-- O CONTEÚDO DAS PÁGINAS DEVE APARECER AQUI -->
-                <?php include './includes/popup.php'; ?>
                 <?php
-                    //SESSAO PARA IMPORTS
                     require_once dirname(__FILE__).'/phpClasses/StatusTrabalho.php';
                 ?>
-                <h2>CRUDs para Status Trabalho</h2>
-                <p>Lista todos Status já cadastrados</p>
+                <h2>Gerenciar Status Trabalho</h2>
+                <button 
+                     onclick='abrePopupForm("Criar Status Trabalho",
+                                 "Criar", "phpFuncoes/cadastrarStatusTrabalho.php",
+                                 <?php
+                                 echo json_encode(array(
+                                     "pStatusTrabalho"=>""));
+                                 ?>,
+                                 {
+                                     pStatusTrabalho:["text", "Status trabalho"]
+                                 });
+                                 return false;'>
+                    Criar Status Trabalho
+                </button>
                 <div id="atualizavel">
-                    <?php
-                        $resultado = StatusTrabalho::getTodosStatusTrabalho();
-                        if($resultado != null){
-                            echo "<ul>";
-                            while($obj = $resultado->fetch_object()){
-                                echo "<li>Id: ".$obj->idStatusTrabalho." - Descrição: ".$obj->descricao."</li>";
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Id</th>
+                                <th>Descrição</th>
+                                <th>Editar</th>
+                                <th>Excluir</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php
+                            $listaStatusTrabalho = StatusTrabalho::getTodosStatusTrabalho();
+                            if($listaStatusTrabalho != null){
+                                foreach($listaStatusTrabalho as $status){
+                            ?>
+                                    <tr>
+                                        <td><?php echo $status->getId() ?></td>
+                                        <td><?php echo $status->getDescricao() ?></td>
+                                        <td>
+                                            <span>
+                                                <img src="img/iconEditar.png"
+                                                     onclick='abrePopupForm("Editar Status Trabalho",
+                                                                 "Editar", "phpFuncoes/editarStatusTrabalho.php",
+                                                                 <?php
+                                                                 echo json_encode(array(
+                                                                     "pIdStatusTrabalho"=>$status->getId(),
+                                                                     "pStatusTrabalho"=>$status->getDescricao()));
+                                                                 ?>,
+                                                                 {
+                                                                     pIdStatusTrabalho:["hidden", ""],
+                                                                     pStatusTrabalho:["text", "Status trabalho"]
+                                                                 });
+                                                                 return false;'>
+                                            </span>
+                                        </td>
+                                        <td>
+                                            <span>
+                                                <img src="img/iconFechar.png"
+                                                     onclick='abrePopupConfirm("Confirma a exclusão do status \"<?php echo $status->getDescricao(); ?>\"?",
+                                                                 "phpFuncoes/excluirStatusTrabalho.php",
+                                                                 "<?php echo $status->getId(); ?>",
+                                                                 "<?php echo $status->getDescricao(); ?>")'>
+                                            </span>
+                                        </td>
+                                    </tr>
+                            <?php
+                                }
                             }
-                            echo "</ul>";
-                        }
-                    ?>
+                            else{
+                                echo "<tr><td colspan='4'>Nenhum registro encontrado!</td></tr>";
+                            }
+                            ?>
+                        </tbody>
+                    </table>
                 </div>
-                <p>Formulário para criar novo Status Trabalho</p>
-                <form action="phpFuncoes/cadastrarStatusTrabalho.php" method="post">
-                    <label for="txtNomeStatusTrabalho">Nome do Status a ser criado: </label>
-                    <input type="text" id="txtNomeStatusTrabalho" name="pStatusTrabalho" placeholder="Novo Status">
-                    <input type="submit" value="Salvar">
-                </form>
-                <p>Formulário para editar Status Trabalho</p>
-                <form action="phpFuncoes/editarStatusTrabalho.php" method="post">
-                    <label for="sltStatusTrabalho">Selecione o Status a ser modificado: </label>
-                    <select id="sltStatusTrabalho" name="pIdStatusTrabalho">
-                        <?php
-                            $resultado = StatusTrabalho::getTodosStatusTrabalho();
-                            while($obj = $resultado->fetch_object()){
-                                echo "<option value='".$obj->idStatusTrabalho."'>".$obj->descricao."</option>";
-                            }
-                        ?>
-                    </select>
-                    <label for="txtNovoNomeStatusTrabalho">Informe a nova descrição do Status: </label>
-                    <input type="text" id="txtNovoNomeStatusTrabalho" name="pStatusTrabalho" placeholder="Nova descrição">
-                    <input type="submit" value="Salvar">
-                </form>
-                <p>Formulário para excluir Status Trabalho</p>
-                <form action="phpFuncoes/excluirStatusTrabalho.php" method="post">
-                    <label for="sltStatusTrabalho">Selecione o Status a ser excluído: </label>
-                    <select id="sltStatusTrabalho" name="pIdStatusTrabalho">
-                        <?php
-                            $resultado = StatusTrabalho::getTodosStatusTrabalho();
-                            while($obj = $resultado->fetch_object()){
-                                echo "<option value='".$obj->idStatusTrabalho."'>".$obj->descricao."</option>";
-                            }
-                        ?>
-                    </select>
-                    <input type="submit" value="Excluir">
-                </form>
             </section>
         </div>
         <?php include './includes/rodape.php'; ?>

--- a/css/formularios.css
+++ b/css/formularios.css
@@ -180,24 +180,19 @@ form a:hover{
     text-decoration: underline;
 }
 /*
-------------------------- FORMS DENTRO DE TABELA
+------------------------- PARA TELAS PEQUENAS
 */
-td form{
-    padding: 0;
-    margin: 0;
-    border: none;
-    background-color: transparent;
-    text-align: center;
-}
-td form input[type="image"]{
-    padding: 0;
-    margin: 0;
-    width: 25px;
-    height: auto;
-    border: none;
-    border-radius: 12px;
-}
-td form input[type="image"]:hover{
-    padding: 2px;
-    background-color: #333;
+@media screen and (max-width: 600px){
+    form{
+        width: 100%;
+        background-color: #EEE;
+        padding: 10px;
+        margin: auto;
+    }
+    fieldset{
+        padding: 5px;
+    }
+    input[type="button"], input[type="reset"], input[type="submit"], button{
+        width: 98%;
+    }
 }

--- a/css/geral.css
+++ b/css/geral.css
@@ -7,6 +7,7 @@
     border-width: 0;
     font-size: 16px;
     font-family: sans-serif;
+    box-sizing: border-box;
 }
 body{
     background-color: #444;
@@ -37,4 +38,13 @@ a{
     display: block;
     color: #383;
     font-size: 16px;
+}
+@media screen and (max-width: 600px){
+    *{
+        padding: 3px;
+        margin: 0;
+    }
+    body, #conteudo{
+        padding: 0;
+    }
 }

--- a/css/menu.css
+++ b/css/menu.css
@@ -37,3 +37,22 @@ nav a:hover{
 #paginaLogin > div:first-child{
     margin-top: -50px;
 }
+@media only screen and (max-width: 600px){
+    #paginaLogin{
+        width: 100%;
+        height: auto;
+        margin: 0;
+        padding: 0;
+    }
+    #paginaLogin > div{
+        display: inline-block;
+        width: 100%;
+    }
+    #paginaLogin > div:last-child{
+        display: none;
+    }
+    #paginaLogin > div:first-child{
+        margin: 0;
+        background-color: transparent;
+    }
+}

--- a/css/popup.css
+++ b/css/popup.css
@@ -1,8 +1,7 @@
 /*
 ------------------------- CONFIGURAÇÕES GERAIS
 */
-#popup { /* ESSA É A DIV QUE FICA MEIO TRANSPARENTE ATRÁS DA TELA */
-    
+#popup { /* ESSA É A DIV QUE FICA MEIO TRANSPARENTE ATRÁS DA TELA */    
     display: none; /* POR PADRÃO NÃO APARECE NA PÁGINA */
     position: fixed; /* IGNORAR POSIÇÃO LOCAL */
     padding-top: 100px; /* Location of the box */
@@ -12,6 +11,7 @@
     overflow: auto; /* PERMITIR SCROLL SE FOR NECESSÁRIO */
     background-color: rgb(0,0,0); /* COR DE FUNDO CASO NÃO SUPORTE OPACIDADE */
     background-color: rgba(0,0,0,0.4); /* COR DE FUNDO CASO SUPORTE OPACIDADE */
+    box-sizing: border-box;
 }
 
 #popup > div { /* POPUP */
@@ -21,7 +21,8 @@
     border-radius: 10px;
     width: 50%; /* LARGURA DA POPUP */
     animation-name: animatetop; /* NOME DA ANIMAÇÃO DEFINIDA ABAIXO */
-    animation-duration: 0.5s /* TEMPO DE EXECUÇÃO DA ANIMAÇÃO */
+    animation-duration: 0.5s; /* TEMPO DE EXECUÇÃO DA ANIMAÇÃO */
+    box-sizing: border-box;
 }
 
 @keyframes animatetop {/* PARÂMETROS DA ANIMAÇÃO (DESLIZAR DE CIMA PARA A POSIÇÃO DEFINIDA) */
@@ -72,4 +73,27 @@
 }
 #popup input[type="button"].fecharPopup:hover {
     background-color: #900;
+}
+/*
+------------------------- PARA TELAS PEQUENAS
+*/
+@media screen and (max-width: 600px){
+    #popup, #popup > div, #popup > div > header{
+        padding: 0;
+        margin: auto;
+        box-sizing: border-box;
+    }
+    #popup > div { /* POPUP */
+        width: 90%; /* LARGURA DA POPUP */
+    }
+    #popup > div > header{
+        padding: 10px;
+    }
+    #popup form{
+        width: 100%;
+        background-color: transparent;
+    }
+    #popup input[type="submit"], #popup input[type="button"]{
+        width: 90%;
+    }
 }

--- a/includes/menu.php
+++ b/includes/menu.php
@@ -1,7 +1,6 @@
 <nav>
     <ul>
         <li><a href="inicio.php" title="Início">Home</a></li>
-        <li><a href="crudStatusTrabalho.php" title="Status trabalho">CRUD Status Trabalho</a></li>
         <li><a href="consultarAvaliacoes.php" title="Consultar avaliações">Consultar Avaliações</a></li>
         <li><a href="testeCamposFormulario.php" title="Campos dos forms">Campos dos FORMs</a></li>
         <?php
@@ -9,9 +8,10 @@
                 //OPÇÕES RESTRITAS AO ADMINISTRADOR
         ?>
         <li>Administrador</li>
-        <li><a href="cadastrarUsuario.php" title="Cadastrar Usuário">Cadastrar Usuário</a></li>
-        <li><a href="cadastrarEvento.php" title="Cadastrar Evento">Cadastrar Evento</a></li>
+        <li><a href="cadastrarUsuario.php" title="Cadastrar usuário">Cadastrar Usuário</a></li>
+        <li><a href="cadastrarEvento.php" title="Cadastrar evento">Cadastrar Evento</a></li>
         <li><a href="crudStatusInscricao.php" title="Status inscricao">Gerenciar Status Inscrição</a></li>
+        <li><a href="crudStatusTrabalho.php" title="Status trabalho">Gerenciar Status Trabalho</a></li>
         <?php
             }//FIM DAS OPÇÕES RESTRITAS AO ADMINISTRADOR
         ?>

--- a/phpClasses/StatusTrabalho.php
+++ b/phpClasses/StatusTrabalho.php
@@ -3,20 +3,15 @@
     require_once dirname(__FILE__).'/../phpDao/StatusTrabalhoDao.php';
 class StatusTrabalho {
 
-    private $id;
+    private $idStatusTrabalho;
     private $descricao;
 
-    function __construct($id, $descricao){
-            $this->id = $id;
-            $this->descricao = $descricao;
-    }
-
     public function getId(){
-            return $this->id;
+            return $this->idStatusTrabalho;
     }
 
     public function setId($id){
-            $this->id = $id;
+            $this->idStatusTrabalho = $id;
     }
 
     public function getDescricao(){
@@ -28,7 +23,35 @@ class StatusTrabalho {
     }
 
     public static function getTodosStatusTrabalho(){
-        return StatusTrabalhoDao::getStatusTrabalho(0, '');
+        $mensagem = array();
+        $listaStatusTrabalho = array();
+        
+        $dados = StatusTrabalhoDao::getStatusTrabalho(0, '');
+        if($dados == null){
+            $mensagem[] = "Nenhum status de inscricao encontrado!";
+        }
+        else{
+            try{
+                while($obj = $dados->fetch_assoc()) {
+                    $statusTrabalho = new StatusTrabalho();
+                    
+                    foreach ($obj as $key => $value) {
+                        $statusTrabalho->{$key} = $value;
+                    }
+                    
+                    $listaStatusTrabalho[] = $statusTrabalho;
+                }
+            } catch (Exception $e) {
+                $listaStatusTrabalho = null;
+                $mensagem[] = $e->getMessage();
+            }
+        }
+        if(count($mensagem) > 0){
+            return $mensagem;
+        }
+        else{
+            return $listaStatusTrabalho;
+        }
     }
     
     public static function getStatusTrabalho($id, $statusTrabalho) {

--- a/phpFuncoes/cadastrarStatusInscricao.php
+++ b/phpFuncoes/cadastrarStatusInscricao.php
@@ -3,28 +3,24 @@
     require dirname(__FILE__).'/../phpClasses/StatusInscricao.php';
 
     $mensagem = array();
-    $titulo = "";
+    $titulo = "Atenção";
 
     if(isset($_POST["pStatusInscricao"])){
         if(empty($_POST["pStatusInscricao"])){  
             $mensagem[] = "Informe um status de inscrição válido!";
-            $titulo = "Atenção";
         }
     }
     else{
         $mensagem[] = "Status de inscrição não informado!";
-        $titulo = "Atenção";
-    }
-    
+    }    
     if(count($mensagem) == 0){
         if(StatusInscricao::salvarStatusInscricao($_POST["pStatusInscricao"]) === TRUE){
-            $mensagem[] = "Status: ".$_POST["pStatusInscricao"]." salvo com sucesso!";
+            $mensagem[] = "Status: '".$_POST["pStatusInscricao"]."' salvo com sucesso!";
             $titulo = "Sucesso";
         }
         else{
             $mensagem[] = "Erro ao tentar salvar: ".$_POST["pStatusInscricao"];
-            $titulo = "Atenção";
         }
     }
-    //echo json_encode(array("mensagem" => $mensagem));
+    
     echo json_encode(array("mensagem" => $mensagem, "titulo" => $titulo));

--- a/phpFuncoes/cadastrarStatusTrabalho.php
+++ b/phpFuncoes/cadastrarStatusTrabalho.php
@@ -3,26 +3,23 @@
     require dirname(__FILE__).'/../phpClasses/StatusTrabalho.php';
 
     $mensagem = array();
-    $titulo = "";
+    $titulo = "Atenção";
 
     if(isset($_POST["pStatusTrabalho"])){
         if(empty($_POST["pStatusTrabalho"])){
             $mensagem[] = "Informe um status de inscricao válido!";
-            $titulo = "Atenção";
         }
     }
     else{
         $mensagem[] = "Status de inscricao não informado!";
-        $titulo = "Atenção";
     }
     if(count($mensagem) == 0){
         if(StatusTrabalho::salvarStatusTrabalho($_POST["pStatusTrabalho"]) === TRUE){
-            $mensagem[] = "Status: ".$_POST["pStatusTrabalho"]." salvo com sucesso!";
+            $mensagem[] = "Status: '".$_POST["pStatusTrabalho"]."' salvo com sucesso!";
             $titulo = "Sucesso";
         }
         else{
             $mensagem[] = "Erro ao tentar salvar: ".$_POST["pStatusTrabalho"];
-            $titulo = "Atenção";
         }
     }
     

--- a/phpFuncoes/excluirStatusTrabalho.php
+++ b/phpFuncoes/excluirStatusTrabalho.php
@@ -3,27 +3,34 @@
     require dirname(__FILE__).'/../phpClasses/StatusTrabalho.php';
     
     $mensagem = array();
-    $titulo = "";
+    $titulo = "Atenção";
+    $pId = 0;
+    $status = "";
 
-    if(isset($_POST["pIdStatusTrabalho"])){
-        if(empty($_POST["pIdStatusTrabalho"])){
-            $mensagem[] = "Informe um status de inscrição válido!";
-            $titulo = "Atenção";
+    if(isset($_POST["pId"])){
+        if(empty($_POST["pId"])){
+            $mensagem[] = "Informe um status trabalho válido!";
         }
     }
     else{
-        $mensagem[] = "Status de inscricao não informado!";
-        $titulo = "Atenção";
+        $mensagem[] = "Status trabalho não informado!";
     }
     
     if(count($mensagem) == 0){
-        if(StatusTrabalho::excluirStatusTrabalho($_POST["pIdStatusTrabalho"]) === TRUE){
-            $mensagem[] = "Status Id: ".$_POST["pIdStatusTrabalho"]." excluído com sucesso!";
+        if(isset($_POST["pDesc"])){
+            if(empty($_POST["pDesc"])){
+                $status = $_POST["pId"];
+            }
+            else{
+                $status = $_POST["pDesc"];
+            }
+        }
+        if(StatusTrabalho::excluirStatusTrabalho($_POST["pId"]) === TRUE){
+            $mensagem[] = "Status: '".$status."' excluído com sucesso!";
             $titulo = "Sucesso";
         }
         else{
-            $mensagem[] = "Erro ao tentar excluir: ".$_POST["pIdStatusTrabalho"];
-            $titulo = "Atenção";
+            $mensagem[] = "Erro ao tentar excluir: '".$status."'";
         }
     }
     echo json_encode(array("mensagem" => $mensagem, "titulo" => $titulo));


### PR DESCRIPTION
 - Página incluída nas opções restritas ao adiministrador
Atualizados arquivos de cadastrarStatusTrabalho.php e excluirStatusTrabalho.php para adaptar ao novo modelo
Retirado parâmetro 'src' de <button> em 'crudStatusInscricao.php'
Página 'cadastrarUsusuario.php' não exibe mais link 'Faça login...' para o administrador logado
Adicionadas regras CSS para telas menores que 600px